### PR TITLE
Fixed API country code bug.

### DIFF
--- a/proxyscrape/integration.py
+++ b/proxyscrape/integration.py
@@ -106,7 +106,7 @@ def get_proxyscrape_resource(proxytype='all', timeout=10000, ssl='all', anonymit
             proxies = set()
             code = None if country == 'all' else country
             anonymous = anonymity in {'elite', 'anonymous'}
-            type = None if 'all' else proxytype
+            type = None if proxytype == 'all' else proxytype
 
             for line in response.text.split():
                 host, port = line.split(':')

--- a/proxyscrape/integration.py
+++ b/proxyscrape/integration.py
@@ -68,7 +68,7 @@ def get_proxyscrape_resource(proxytype='all', timeout=10000, ssl='all', anonymit
     proxytype = proxytype.lower()
     ssl = ssl.lower()
     anonymity = anonymity.lower()
-    country = country.lower()
+    country = country.upper()
 
     if proxytype not in {'http', 'socks4', 'socks5', 'all'}:
         raise ValueError('proxytype %s is not valid' % proxytype)

--- a/proxyscrape/integration.py
+++ b/proxyscrape/integration.py
@@ -106,7 +106,7 @@ def get_proxyscrape_resource(proxytype='all', timeout=10000, ssl='all', anonymit
             proxies = set()
             code = None if country == 'all' else country
             anonymous = anonymity in {'elite', 'anonymous'}
-            type = None if proxytype == 'all' else proxytype
+            type = None if 'all' else proxytype
 
             for line in response.text.split():
                 host, port = line.split(':')


### PR DESCRIPTION
When a country code other than 'all' is used, such as 'us' or 'br', the API returns no proxies. This is because the API only accepts upper case country codes. If 'US' or 'BR' is used, proxies are returned. Either the API needs to be changed to use lower case country codes, or `get_proxyscrape_resource` needs to be updated to enforce upper case country codes.