### PR TITLE
Bug fix - Fixed `type` always being set to `None`.

### DIFF
--- a/proxyscrape/integration.py
+++ b/proxyscrape/integration.py
@@ -106,7 +106,7 @@ def get_proxyscrape_resource(proxytype='all', timeout=10000, ssl='all', anonymit
             proxies = set()
             code = None if country == 'all' else country
             anonymous = anonymity in {'elite', 'anonymous'}
-            type = None if 'all' else proxytype
+            type = None if proxytype == 'all' else proxytype
 
             for line in response.text.split():
                 host, port = line.split(':')


### PR DESCRIPTION
BUG: In `get_proxyscrape_resource`, `type` always gets set to `None` when creating a `Proxy` no matter what the `proxytype` value is . This is because the ternary expression is missing some logic.

FIX: Added missing logic.