### PR TITLE
Fix/proxytype filters

### DIFF
--- a/proxyscrape/integration.py
+++ b/proxyscrape/integration.py
@@ -109,7 +109,7 @@ def get_proxyscrape_resource(proxytype='all', timeout=10000, ssl='all', anonymit
             type = None if proxytype == 'all' else proxytype
 
             for line in response.text.split():
-                host, port = line.split(':')
+                host, port = map(str, line.split(':'))
                 proxies.add(Proxy(host, port, code, None, anonymous, type, name))
 
             return proxies

--- a/proxyscrape/proxyscrape.py
+++ b/proxyscrape/proxyscrape.py
@@ -131,7 +131,7 @@ class Collector:
         if resource_types is not None:
             self._resource_types = set(resource_types) if is_iterable(resource_types) else {resource_types, }
             self._validate_resource_types(self._resource_types)
-            self._filter_opts = {'type': self._resource_types.copy()}
+            self._filter_opts = {}
         else:
             self._resource_types = None
             self._filter_opts = {}

--- a/tests/test_proxyscrape.py
+++ b/tests/test_proxyscrape.py
@@ -529,25 +529,6 @@ class TestCollector(unittest.TestCase):
         for _, attrs in collector._resource_map.items():
             store_mock.update_store.assert_called_with(attrs['id'], proxies)
 
-    def test(self):
-        from proxyscrape.integration import get_proxyscrape_resource
-        from proxyscrape.scrapers import add_resource_type
-
-        # Create proxyscrape api resource
-        api_resource = get_proxyscrape_resource(proxytype='http', timeout=5000, ssl='yes', anonymity='all',
-                                                country='us')
-
-        # Add api resource to new resource type
-        add_resource_type("api", api_resource)
-
-        # Create collector
-        api_collector = create_collector('api-collector', 'api')
-
-        # Get proxies
-        proxy = api_collector.get_proxy()
-
-        print(proxy)
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_proxyscrape.py
+++ b/tests/test_proxyscrape.py
@@ -31,7 +31,6 @@ try:
 except ImportError:
     from mock import Mock
 
-# TODO: Change these to not be *
 from proxyscrape.errors import (
      CollectorAlreadyDefinedError,
      CollectorNotFoundError,


### PR DESCRIPTION
Fixes issue #14.

When creating resource_types, the names were being used as a filter for `type`. This was originally included in the case of implicitly filtering proxies from funcs that pull in multiple types and the names happened to be 'http', 'https', 'socks4', or 'socks5'.. However, this causes problems when creating custom resources that don't fit this criteria.

By removing this filter, it is up to the user to explicitly add a filter if they are using resource_types which can pull in multiple proxytypes and only want a specific one.
